### PR TITLE
Regex too greedy and broke todolist items with links

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -20,7 +20,7 @@ const getAllLinkMatchesInFile = async (mdFile: TFile, plugin: LinkConverterPlugi
     let fileText = await plugin.app.vault.read(mdFile);
 
     // --> Get All WikiLinks
-    let wikiRegex = /\[\[.*?\]\]/g;
+    let wikiRegex = /\[\[[^\]]*?\]\]/g;
     let wikiMatches = fileText.match(wikiRegex);
 
     if (wikiMatches) {
@@ -63,7 +63,7 @@ const getAllLinkMatchesInFile = async (mdFile: TFile, plugin: LinkConverterPlugi
     }
 
     // --> Get All Markdown Links
-    let markdownRegex = /\[(^$|.*?)\]\((.*?)\)/g;
+    let markdownRegex = /\[([^\]]*?)\]\(([^)]*?)\)/g;
     let markdownMatches = fileText.match(markdownRegex);
 
     if (markdownMatches) {
@@ -357,11 +357,11 @@ function getRelativeLink(sourceFilePath: string, linkedFilePath: string) {
 
 /* -------------------- TRANSCLUSIONS -------------------- */
 
-const wikiTransclusionRegex = /\[\[(.*?)#.*?\]\]/;
+const wikiTransclusionRegex = /\[\[([^\]]*?)#.*?\]\]/;
 const wikiTransclusionFileNameRegex = /(?<=\[\[)(.*)(?=#)/;
 const wikiTransclusionBlockRef = /(?<=#).*?(?=]])/;
 
-const mdTransclusionRegex = /\[.*?]\((.*?)#.*?\)/;
+const mdTransclusionRegex = /\[[^\]]*?]\(([^)]*?)#[^\)]*?\)/;
 const mdTransclusionFileNameRegex = /(?<=\]\()(.*)(?=#)/;
 const mdTransclusionBlockRef = /(?<=#).*?(?=\))/;
 


### PR DESCRIPTION
When I have 
```
- [ ] [hello world](./hello-world.md)
```

The regex would match ` ] [hello world` and destroy the todo list.

Before: https://regex101.com/r/z3rvU2/1
After: https://regex101.com/r/6Xk8jq/1

Note - I haven't extensively tested this yet!